### PR TITLE
Fix DB structure and queries for MySQL

### DIFF
--- a/web/private/InitMySQL.sql
+++ b/web/private/InitMySQL.sql
@@ -14,5 +14,6 @@ CREATE TABLE Keepass (
   CreationDate timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   UserId varchar(255) NOT NULL,
   PublicKey varchar(512) NOT NULL,
-  FOREIGN KEY (UserId) REFERENCES USER(UserId)
+  INDEX (UserId),
+  FOREIGN KEY (UserId) REFERENCES Users(UserId)
 ) ENGINE=MyISAM DEFAULT CHARSET utf8;

--- a/web/private/InitMySQL.sql
+++ b/web/private/InitMySQL.sql
@@ -1,19 +1,18 @@
-DROP TABLE IF EXISTS KEEPASS;
-DROP TABLE IF EXISTS USER;
+DROP TABLE IF EXISTS Keepass;
+DROP TABLE IF EXISTS Users;
 
-CREATE TABLE USER (
-  User_Id varchar(255) NOT NULL PRIMARY KEY,
-  Last_Access timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  Sid_Created int unsigned NOT NULL DEFAULT 1
+CREATE TABLE Users(
+  UserId varchar(255) NOT NULL PRIMARY KEY,
+  LastAccess timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  SidCreated int unsigned NOT NULL DEFAULT 1
 ) ENGINE=MyISAM DEFAULT CHARSET utf8;
 
-CREATE TABLE KEEPASS (
-  Session_Id varchar(255) NOT NULL PRIMARY KEY,
+CREATE TABLE Keepass (
+  SessionId varchar(255) NOT NULL PRIMARY KEY,
   Username longtext,
   Psw longtext,
-  Creation_Date timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  User_Id varchar(255) NOT NULL,
-  Public_Key varchar(512) NOT NULL,
-
-  FOREIGN KEY (User_Id) REFERENCES USER(User_Id)
+  CreationDate timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UserId varchar(255) NOT NULL,
+  PublicKey varchar(512) NOT NULL,
+  FOREIGN KEY (UserId) REFERENCES USER(UserId)
 ) ENGINE=MyISAM DEFAULT CHARSET utf8;

--- a/web/private/config.default.ini
+++ b/web/private/config.default.ini
@@ -1,6 +1,6 @@
 ; This is a sample configuration file
-host = 127.0.0.1
+host = "127.0.0.1"
 port = 3306
-dbname = keelink
-username = dbusername
-password = dbpassword
+dbname = "keelink"
+username = "dbusername"
+password = "dbpassword"


### PR DESCRIPTION
Added some fixes for MySQL compatibility.

DB Structure has changed because MySQL warns about a table called "USER" and I changed from "User_Id" to "UserId" to respect CamelCase.

NOTE: I'm not sure about the foreign key, because even if syntax looks good, from phpMyAdmin I don't have any reference about it, quite strange..